### PR TITLE
Feature: Option to skip checking main module

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,7 @@ Revision history for Dist-Zilla-Plugin-OurPkgVersion
 
 {{$NEXT}}
   - Fix bug where nw underscore_eval_version may fail
+  - add skip_main_module option for compatibility with VersionFromMainModule
 
 0.12      2017-07-11
   - Add underscore_eval_version property

--- a/corpus/DZT/lib/DZT8.pm
+++ b/corpus/DZT/lib/DZT8.pm
@@ -1,6 +1,0 @@
-use strict;
-use warnings;
-package DZT0;
-our $VERSION = '0.1.0'; # VERSION
-# ABSTRACT: my abstract
-1;

--- a/corpus/DZT/lib/DZT8.pm
+++ b/corpus/DZT/lib/DZT8.pm
@@ -1,0 +1,6 @@
+use strict;
+use warnings;
+package DZT0;
+our $VERSION = '0.1.0'; # VERSION
+# ABSTRACT: my abstract
+1;

--- a/corpus/sDZT/dist.ini
+++ b/corpus/sDZT/dist.ini
@@ -1,0 +1,13 @@
+name    = DZT0
+author  = Caleb Cushing <xenoterracide@gmail.com>
+license =  Artistic_2_0
+version = 0.1.0
+copyright_holder = Caleb Cushing
+
+[@Filter]
+-bundle = @Basic
+-remove = Readme
+
+[OurPkgVersion]
+skip_main_module = 1
+

--- a/corpus/sDZT/lib/DZT0.pm
+++ b/corpus/sDZT/lib/DZT0.pm
@@ -1,0 +1,6 @@
+use strict;
+use warnings;
+package DZT0;
+# VERSION
+# ABSTRACT: my abstract
+1;

--- a/corpus/sDZT/lib/DZT1.pm
+++ b/corpus/sDZT/lib/DZT1.pm
@@ -1,0 +1,8 @@
+use strict;
+use warnings;
+package DZT1;
+BEGIN {
+	# VERSION
+}
+# ABSTRACT: my abstract
+1;

--- a/lib/Dist/Zilla/Plugin/OurPkgVersion.pm
+++ b/lib/Dist/Zilla/Plugin/OurPkgVersion.pm
@@ -265,6 +265,12 @@ immediately after the our version assignment:
 This is arguably the correct thing to do, but changes the line numbering
 of the generated Perl module or source, and thus optional.
 
+=item skip_main_module
+
+Set to true to ignore the main module in the distribution. This prevents
+a warning when using L<Dist::Zilla::Plugin::VersionFromMainModule> to
+obtain the version number instead of the C<dist.ini> file.
+
 =back
 
 =cut

--- a/lib/Dist/Zilla/Plugin/OurPkgVersion.pm
+++ b/lib/Dist/Zilla/Plugin/OurPkgVersion.pm
@@ -32,10 +32,19 @@ has underscore_eval_version => (
   default => 0,
 );
 
+has skip_main_module => (
+  is      => 'ro',
+  isa     => 'Int',
+  default => 0,
+);
+
 sub munge_files {
 	my $self = shift;
 
-	$self->munge_file($_) for @{ $self->found_files };
+	$self->munge_file($_) for
+		grep { $self->skip_main_module ? $_->name ne $self->zilla->main_module->name : 1 }
+		@{ $self->found_files };
+
 	return;
 }
 

--- a/t/05-skip_main_module.t
+++ b/t/05-skip_main_module.t
@@ -1,0 +1,47 @@
+#!/usr/bin/perl
+
+# test that skip_main_module ignores the main module (DZT0.pm in this case)
+
+use strict;
+use warnings;
+use Test::More;
+use Test::DZil;
+use Test::Version qw( version_ok );
+use Path::Tiny qw( path );
+
+my $tzil = Builder->from_config({ dist_root => 'corpus/sDZT' });
+
+$tzil->build;
+
+version_ok( path($tzil->tempdir)->child('build/lib/DZT1.pm'));
+
+my $lib_0 = $tzil->slurp_file('build/lib/DZT0.pm');
+my $lib_1 = $tzil->slurp_file('build/lib/DZT1.pm');
+
+# e short for expected files
+# -------------------------------------------------------------------
+my $elib_0 = <<'END LIB0';
+use strict;
+use warnings;
+package DZT0;
+# VERSION
+# ABSTRACT: my abstract
+1;
+END LIB0
+
+my $elib_1 = <<'END LIB1';
+use strict;
+use warnings;
+package DZT1;
+BEGIN {
+	our $VERSION = '0.1.0'; # VERSION
+}
+# ABSTRACT: my abstract
+1;
+END LIB1
+# -------------------------------------------------------------------
+
+is ( $lib_0, $elib_0, 'check DZT0.pm' );
+is ( $lib_1, $elib_1, 'check DZT1.pm' );
+
+done_testing;


### PR DESCRIPTION
Hi,

Firstly, thanks for your module. This PR is for a small change to make it more compatible with Dist::Zilla::Plugin::VersionFromMainModule - currently there will always be the warning about "No #VERSION in module...".

I considered changing the regex to not add the version if there was one already, but thought that was more fragile and could hide any problems (for example if an incorrect version number was copy-and-pasted in).

thanks,
Michael
