### PR TITLE
Feature overwrite

### DIFF
--- a/corpus/DZT/lib/DZT8.pm
+++ b/corpus/DZT/lib/DZT8.pm
@@ -11,7 +11,7 @@ END
 
 =cut
 
-our $VERSION= ''; # VERSION
+our $VERSION = ''; # VERSION
 
 1;
 __END__

--- a/corpus/DZT/lib/DZT8.pm
+++ b/corpus/DZT/lib/DZT8.pm
@@ -1,0 +1,19 @@
+use strict;
+use warnings;
+package DZT8;
+<<END
+# VERSION
+END
+
+=pod
+
+# VERSION
+
+=cut
+
+our $VERSION= ''; # VERSION
+
+1;
+__END__
+
+# VERSION

--- a/corpus/oDZT/dist.ini
+++ b/corpus/oDZT/dist.ini
@@ -1,0 +1,10 @@
+name    = oDZT
+author  = Caleb Cushing <xenoterracide@gmail.com>
+license = Artistic_2_0
+version = v0.1.0
+copyright_holder = Caleb Cushing
+
+[@Basic]
+
+[OurPkgVersion]
+overwrite = 1

--- a/corpus/oDZT/lib/oDZT.pm
+++ b/corpus/oDZT/lib/oDZT.pm
@@ -1,0 +1,20 @@
+use strict;
+use warnings;
+package oDZT;
+# ABSTRACT: lots of false leads here
+<<END
+# VERSION
+END
+
+=pod
+
+# VERSION
+
+=cut
+
+our $VERSION= ''; # VERSION
+
+1;
+__END__
+
+# VERSION

--- a/corpus/oDZT/lib/oDZT.pm
+++ b/corpus/oDZT/lib/oDZT.pm
@@ -14,6 +14,10 @@ END
 
 our $VERSION= ''; # VERSION
 
+BEGIN { our $VERSION= 0; } # VERSION
+
+our $FOO= 1; our $VERSION= 0; our $BAR= 2; # VERSION
+
 1;
 __END__
 

--- a/corpus/oDZT/lib/oDZT.pm
+++ b/corpus/oDZT/lib/oDZT.pm
@@ -12,11 +12,11 @@ END
 
 =cut
 
-our $VERSION= ''; # VERSION
+our $VERSION = ''; # VERSION
 
 BEGIN { our $VERSION= 0; } # VERSION
 
-our $FOO= 1; our $VERSION= 0; our $BAR= 2; # VERSION
+our $FOO = 1; our $VERSION=0; our $BAR = 2; # VERSION
 
 1;
 __END__

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -110,7 +110,7 @@ END
 
 =cut
 
-our $VERSION= ''; our $VERSION = '0.1.0'; # VERSION
+our $VERSION = ''; our $VERSION = '0.1.0'; # VERSION
 
 1;
 __END__

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -21,6 +21,7 @@ my $lib_4 = $tzil->slurp_file('build/lib/DZT4.pm');
 my $lib_5 = $tzil->slurp_file('build/lib/DZT5.pm');
 my $lib_6 = $tzil->slurp_file('build/lib/DZT6.pm');
 my $lib_7 = $tzil->slurp_file('build/lib/DZT7.pm');
+my $lib_8 = $tzil->slurp_file('build/lib/DZT8.pm');
 my $tst_0 = $tzil->slurp_file('build/t/basic.t'  );
 
 # e short for expected files
@@ -95,6 +96,28 @@ our $VERSION = '0.1.0'; ## VERSION
 1;
 END LIB7
 
+my $elib_8 = <<'END LIB8';
+use strict;
+use warnings;
+package DZT8;
+<<END
+# VERSION
+END
+
+=pod
+
+# VERSION
+
+=cut
+
+our $VERSION= ''; our $VERSION = '0.1.0'; # VERSION
+
+1;
+__END__
+
+# VERSION
+END LIB8
+
 my $etst_0 = <<'END TST0';
 #!/usr/bin/perl
 # VERSION
@@ -109,6 +132,7 @@ is ( $lib_4, $elib_4, 'check DZT4.pm' );
 is ( $lib_5, $elib_5, 'check DZT5.pm' );
 is ( $lib_6, $elib_6, 'check DZT6.pm' );
 is ( $lib_7, $elib_7, 'check DZT7.pm' );
+is ( $lib_8, $elib_8, 'check DZT8.pm' );
 is ( $tst_0, $etst_0, 'check basic.t' );
 
 for my $file ( qw/DZT2 DZT3/ ) {

--- a/t/06-overwrite.t
+++ b/t/06-overwrite.t
@@ -1,0 +1,46 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use Test::More;
+use Test::DZil;
+use Test::Version qw( version_ok );
+use Path::Tiny qw( path );
+
+my $tzil = Builder->from_config({ dist_root => 'corpus/oDZT' });
+
+$tzil->build;
+
+version_ok( path($tzil->tempdir)->child('build/lib/oDZT.pm'));
+
+my $lib_0 = $tzil->slurp_file('build/lib/oDZT.pm');
+
+# e short for expected files
+# -------------------------------------------------------------------
+
+my $elib_0 = <<'END LIB8';
+use strict;
+use warnings;
+package oDZT;
+<<END
+# VERSION
+END
+
+=pod
+
+# VERSION
+
+=cut
+
+our $VERSION= '0.1.0'; # VERSION
+
+1;
+__END__
+
+# VERSION
+END LIB8
+
+# -------------------------------------------------------------------
+
+is ( $lib_0, $elib_0, 'check oDZT.pm' );
+
+done_testing;

--- a/t/06-overwrite.t
+++ b/t/06-overwrite.t
@@ -32,11 +32,11 @@ END
 
 =cut
 
-our $VERSION= 'v0.1.0'; # VERSION
+our $VERSION = 'v0.1.0'; # VERSION
 
 BEGIN { our $VERSION= 'v0.1.0'; } # VERSION
 
-our $FOO= 1; our $VERSION= 'v0.1.0'; our $BAR= 2; # VERSION
+our $FOO = 1; our $VERSION='v0.1.0'; our $BAR = 2; # VERSION
 
 1;
 __END__

--- a/t/06-overwrite.t
+++ b/t/06-overwrite.t
@@ -21,6 +21,7 @@ my $elib_0 = <<'END LIB8';
 use strict;
 use warnings;
 package oDZT;
+# ABSTRACT: lots of false leads here
 <<END
 # VERSION
 END
@@ -31,7 +32,7 @@ END
 
 =cut
 
-our $VERSION= '0.1.0'; # VERSION
+our $VERSION= 'v0.1.0'; # VERSION
 
 1;
 __END__

--- a/t/06-overwrite.t
+++ b/t/06-overwrite.t
@@ -34,6 +34,10 @@ END
 
 our $VERSION= 'v0.1.0'; # VERSION
 
+BEGIN { our $VERSION= 'v0.1.0'; } # VERSION
+
+our $FOO= 1; our $VERSION= 'v0.1.0'; our $BAR= 2; # VERSION
+
 1;
 __END__
 


### PR DESCRIPTION
This is one possible implementation for an ``overwrite`` feature.  It finds the comment first, then if the comment doesn't begin at start of line it searches for the earlier tokens, finds ``our $VERSION=X;`` within those tokens, and replaces only ``X``.  If the prefix doesn't match then it is ignored and continues with previous behavior.  Let me know if you'd like something more restrictive or named differently.