### PR TITLE
Added semantic version support

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,10 @@ becomes
 
 # METHODS
 
+- BUILD
+
+    Provides validations after object creation.
+
 - munge\_files
 
     Override the default provided by [Dist::Zilla::Role::FileMunger](https://metacpan.org/pod/Dist::Zilla::Role::FileMunger) to limit
@@ -120,7 +124,7 @@ becomes
 
 - munge\_file
 
-    tells which files to munge, see [Dist::Zilla::Role::FileMunger](https://metacpan.org/pod/Dist::Zilla::Role::FileMunger)
+    tells which files to munge, see [Dist::Zilla::Role::FileMunger](https://metacpan.org/pod/Dist::Zilla::Role::FileMunger).
 
 - finder
 
@@ -137,10 +141,25 @@ becomes
     For version numbers that have an underscore in them, add this line
     immediately after the our version assignment:
 
-        $VERSION = eval $VERSION;
+            $VERSION = eval $VERSION;
 
     This is arguably the correct thing to do, but changes the line numbering
     of the generated Perl module or source, and thus optional.
+
+- semantic\_version
+
+    Setting this property to "true" (1) will set the version of the
+    module/distribution to properly use semantic versioning. It will also expect
+    that you setup `version` with a v-string, without adding quotes. For example:
+
+            version = v0.0.1
+
+    Beware you can't setup both `underscore_eval_version` and `semantic_version`
+    since both are mutually exclusive: if you try, your code is going to `die`.
+
+    For more details, check
+    [this blog](https://weblog.bulknews.net/how-to-correctly-use-semantic-version-vx-y-z-in-perl-modules-eb08568ab911)
+    for more details about using semantic version with Perl.
 
 - skip\_main\_module
 
@@ -168,9 +187,11 @@ feature.
 
 # CONTRIBUTORS
 
-- Alexandr Ciornii <alexchorny@gmail.com>
+- Alceu Rodrigues de Freitas Junior <arfreitas@cpan.org>
+- Michael Conrad <mike@nrdvana.net>
 - Michael Jemmeson <mjemmeson@cpan.org>
 - Stephan Loyd <stephanloyd9@gmail.com>
+- Alexandr Ciornii <alexchorny@gmail.com>
 - Alexei Znamensky <russoz@cpan.org>
 - Christian Walde <walde.christian@googlemail.com>
 - Christopher J. Madsen <perl@cjmweb.net>
@@ -179,7 +200,6 @@ feature.
 - Graham Ollis <plicease@cpan.org>
 - Graham✈️✈️ <plicease@cpan.org>
 - Ian Sealy <git@iansealy.com>
-- Michael Conrad <mike@nrdvana.net>
 
 # AUTHORS
 

--- a/corpus/error1/dist.ini
+++ b/corpus/error1/dist.ini
@@ -1,0 +1,11 @@
+name    = semanticDZT
+author  = Caleb Cushing <xenoterracide@gmail.com>
+license = Artistic_2_0
+version = v0.0.1
+copyright_holder = Caleb Cushing
+
+[@Basic]
+
+[OurPkgVersion]
+semantic_version = 1
+underscore_eval_version = 1

--- a/corpus/error1/lib/DZT0.pm
+++ b/corpus/error1/lib/DZT0.pm
@@ -1,0 +1,6 @@
+use strict;
+use warnings;
+package DZT0;
+# VERSION
+# ABSTRACT: my abstract
+1;

--- a/corpus/error2/dist.ini
+++ b/corpus/error2/dist.ini
@@ -1,0 +1,10 @@
+name    = semanticDZT
+author  = Caleb Cushing <xenoterracide@gmail.com>
+license = Artistic_2_0
+version = v0.0;1
+copyright_holder = Caleb Cushing
+
+[@Basic]
+
+[OurPkgVersion]
+semantic_version = 1

--- a/corpus/error2/lib/DZT0.pm
+++ b/corpus/error2/lib/DZT0.pm
@@ -1,0 +1,6 @@
+use strict;
+use warnings;
+package DZT0;
+# VERSION
+# ABSTRACT: my abstract
+1;

--- a/corpus/semanticDZT/dist.ini
+++ b/corpus/semanticDZT/dist.ini
@@ -1,0 +1,10 @@
+name    = semanticDZT
+author  = Caleb Cushing <xenoterracide@gmail.com>
+license = Artistic_2_0
+version = v0.0.1
+copyright_holder = Caleb Cushing
+
+[@Basic]
+
+[OurPkgVersion]
+semantic_version = 1

--- a/corpus/semanticDZT/lib/semanticDZT.pm
+++ b/corpus/semanticDZT/lib/semanticDZT.pm
@@ -1,0 +1,6 @@
+package semanticDZT;
+use warnings;
+use strict;
+# VERSION
+# ABSTRACT: my abstract
+1;

--- a/dist.ini
+++ b/dist.ini
@@ -13,7 +13,7 @@ copyright_holder = Caleb Cushing
 type     = text
 filename = README
 location = build
-    
+
 [ReadmeAnyFromPod / ReadMePodInRoot]
 type     = markdown
 filename = README.md
@@ -38,28 +38,30 @@ cpan = 1
 
 [AutoPrereqs]
 [Prereqs]
-        Dist::Zilla = 6.00
-	Dist::Zilla::Role::FileMunger = 0
-	Dist::Zilla::Role::FileFinderUser = 0
+  Dist::Zilla = 6.00
+  Dist::Zilla::Role::FileMunger = 0
+  Dist::Zilla::Role::FileFinderUser = 0
 [Prereqs / TestRequires]
-	Test::Version = 0.04
-
+  Test::Version = 0.04
+  Test::Pod::Coverage = 1.10
+  Perl::Critic::More = 1.003
+  Perl::Critic::Pulp = 96
 [OurPkgVersion]
 [PodWeaver]
 
 [AutoMetaResources]
-	homepage = https://metacpan.org/dist/%{dist}
-	bugtracker.github = user:plicease
-	repository.github = user:plicease
+homepage = https://metacpan.org/dist/%{dist}
+bugtracker.github = user:plicease
+repository.github = user:plicease
 
 [MetaNoIndex]
-	directory = corpus
-	file = perlcritic.rc
+directory = corpus
+file = perlcritic.rc
 
 [MetaJSON]
 
 [NextRelease]
-	format = %-9v %{yyyy-MM-dd}d
+format = %-9v %{yyyy-MM-dd}d
 
 [Test::ReportPrereqs]
 [@TestingMania]

--- a/lib/Dist/Zilla/Plugin/OurPkgVersion.pm
+++ b/lib/Dist/Zilla/Plugin/OurPkgVersion.pm
@@ -24,7 +24,7 @@ use namespace::autoclean;
 
 has underscore_eval_version => (
   is      => 'ro',
-  isa     => 'Int',
+  isa     => 'Bool',
   default => 0,
 );
 
@@ -36,13 +36,13 @@ has semantic_version => (
 
 has skip_main_module => (
   is      => 'ro',
-  isa     => 'Int',
+  isa     => 'Bool',
   default => 0,
 );
 
 has overwrite => (
   is      => 'ro',
-  isa     => 'Int',
+  isa     => 'Bool',
   default => 0,
 );
 
@@ -66,6 +66,7 @@ sub BUILD {
 	confess 'invalid characters in version'
 		unless LaxVersionStr->check( $self->zilla->version );  ## no critic (Modules::RequireExplicitInclusion)
 
+	return 1;
 }
 
 sub munge_file {
@@ -113,7 +114,7 @@ sub munge_file {
 						;
 
 				if ( $self->semantic_version ) {
-				  confess 'Invalid semantic version syntax declaration in INI file' unless ( $version =~ /^v\d+\.\d+\.\d+$/ );
+				  confess 'Invalid semantic version syntax declaration in INI file' unless ( $version =~ /^v\d+\.\d+\.\d+$/x );
 					$code = "use version;\n" . $code;
 				}
 
@@ -299,6 +300,10 @@ becomes
 =head1 METHODS
 
 =over
+
+=item BUILD
+
+Provides validations after object creation.
 
 =item munge_files
 

--- a/t/07-semantic.t
+++ b/t/07-semantic.t
@@ -1,0 +1,31 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use Test::More;
+use Test::DZil;
+use Test::Version qw( version_ok );
+use Path::Tiny qw( path );
+
+my $package = 'semanticDZT';
+my $module  = "$package.pm";
+my $tzil    = Builder->from_config( { dist_root => "corpus/$package" } );
+$tzil->build;
+version_ok( path( $tzil->tempdir )->child("build/lib/$module") );
+my $lib_0 = $tzil->slurp_file("build/lib/$module");
+
+# e short for expected files
+# -------------------------------------------------------------------
+my $elib_0 = <<"END LIB0";
+package $package;
+use warnings;
+use strict;
+use version;
+our \$VERSION = 'v0.0.1'; # VERSION
+# ABSTRACT: my abstract
+1;
+END LIB0
+
+# -------------------------------------------------------------------
+
+is( $lib_0, $elib_0, "check $module" );
+done_testing;

--- a/t/08-build_exceptions.t
+++ b/t/08-build_exceptions.t
@@ -1,0 +1,19 @@
+use strict;
+use warnings;
+use Test::More;
+use Test::Exception;
+use Test::DZil;
+
+my $package = 'error1';
+my $module  = "$package.pm";
+
+dies_ok { Builder->from_config( { dist_root => "corpus/$package" } ) }
+'cannot use both underscore_eval_version and semantic_version attributes';
+
+$package = 'error2';
+$module  = "$package.pm";
+
+dies_ok { Builder->from_config( { dist_root => "corpus/$package" } ) }
+'rejects invalid version number';
+
+done_testing;


### PR DESCRIPTION
Implemented semantic version support as documented in
https://weblog.bulknews.net/how-to-correctly-use-semantic-version-vx-y-z-in-perl-modules-eb08568ab911.
Added required files for unit testing.
Created a new attribute called `semantic_version`.
Created a `BUILD` method to add validation to not allow setting up both
`underscore_eval_version` and `semantic_version` attributes.
Moved the version string validation (`LaxVersionStr`) to the `BUILD` method
as well.
Updated the Pod as well.